### PR TITLE
Add pushState/hashChange support to CherryTree out of the box

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 bower_components
+node_modules

--- a/README.md
+++ b/README.md
@@ -4,6 +4,23 @@ It's build on top of [tildeio/router.js](https://github.com/tildeio/router.js) w
 
 Cherrytree is AMD and a bower component.
 
+## Location
+
+Cherrytree can be configured to use differet implementations of libraries that manager browser's URL/history. By default, Cherrytree will use `location/none_location` which means browser's URL/history won't be managed at all, and navigating around the application will only be possible programatically. However, Cherrytree also ships with a very versatile `location/history_location` which uses `location-bar` module to enable `pushState` or `hashChange` based URL management with graceful fallback of `pushState` -> `hashChange` -> `polling` depending on browser's capabilities. What his means is that out of the box cherrytree can hook into browser's URL for managing your application's state. Here's an example of how to use this functionality:
+
+```js
+  var Router = require("cherrytree");
+  var HistoryLocation = require("cherrytree/location/history_location");
+
+  var router = new Router({
+    location: new HistoryLocation({
+      pushState: true
+    })
+  });
+```
+
+As you can see you can also provide your own implementation of location. For example, if you're already using `Backbone`, you might wanna use `Backbone.History` to manage the `hashChange` events and you could easily hook that into Cherrytree.
+
 TODO
   * docs
   * tests :-"

--- a/bower.json
+++ b/bower.json
@@ -11,9 +11,13 @@
     "tests"
   ],
   "dependencies": {
-    "router.js": "KidkArolis/router.js#1e31941370d6152b181cddece6b5be48223ef04a",
+    "router.js": "KidkArolis/router.js#5fb31311fc7c0ea4b397be7f90068949849a6cec",
     "route-recognizer": "tildeio/route-recognizer#7d78b62279f0ceff22ec7783c43e36efe4a8e336",
-    "rsvp": "rsvp#2.0.1",
+    "location-bar": "1.0.0",
+    "rsvp": "2.0.1",
     "underscore": ">=1.4.4"
+  },
+  "devDependencies": {
+    "jquery": "~2.0.3"
   }
 }

--- a/location/history_location.js
+++ b/location/history_location.js
@@ -1,0 +1,137 @@
+define(function (require) {
+
+  var extend      = require("../util/extend");
+  var LocationBar = require("location-bar");
+
+  // save the current scroll position at all times
+  // for use when back/forward buttons are used
+  var $ = require("jquery");
+  var currentScroll;
+  $(window).scroll(function () {
+    currentScroll = window.scrollY;
+  });
+
+  var HistoryLocation = function (options) {
+    this.options = extend({}, this.options);
+    this.options = extend(this.options, options);
+    this.initialize(this.options);
+  };
+  HistoryLocation.prototype = {
+    path: "",
+
+    options: {
+      pushState: false,
+      root: "/"
+    },
+
+    initialize: function (options) {
+      var self = this;
+
+      this.locationBar = new LocationBar();
+
+      this.locationBar.onChange(function (path) {
+        path = path || "";
+
+        // experimental feature: preserving scroll upon
+        // navigation
+        window.scrollTo(0, currentScroll);
+        setTimeout(function () {
+          window.scrollTo(0, currentScroll);
+        }, 0);
+        setTimeout(function () {
+          window.scrollTo(0, currentScroll);
+        }, 1);
+
+        // var query = path.split("?")[1];
+        path = path.split("?")[0];
+        self.handleURL("/" + path);
+
+        // for now, we publish the url:params via mediator
+        // we should get some better inspiration from ember-query
+        // about how we could pass these in via the router into the
+        // states
+        // var mediator = require("leap/mediator");
+        // mediator.publish("url:params", query);
+      });
+      this.locationBar.start(extend(options));
+    },
+
+    usesPushState: function () {
+      return this.options.pushState;
+    },
+
+    getURL: function () {
+      return this.path;
+    },
+
+    navigate: function (url) {
+      this.locationBar.update(url, {trigger: true});
+    },
+
+    setURL: function (path) {
+      if (this.path !== path) {
+        this.path = path;
+        this.locationBar.update(path, {trigger: false});
+        if (this.changeCallback) {
+          this.changeCallback(this.path);
+        }
+      }
+    },
+
+    replaceURL: function (path) {
+      if (this.path !== path) {
+        this.path = path;
+        this.locationBar.update(path, {trigger: false, replace: true});
+        if (this.changeCallback) {
+          this.changeCallback(this.path);
+        }
+      }
+    },
+
+    // when the url
+    onChangeURL: function (callback) {
+      this.changeCallback = callback;
+    },
+
+    // callback for what to do when backbone router handlers a URL
+    // change
+    onUpdateURL: function (callback) {
+      this.updateCallback = callback;
+    },
+
+    handleURL: function (url) {
+      this.path = url;
+      // initially, the updateCallback won't be defined yet, but that's good
+      // because we dont' want to kick off routing right away, the router
+      // does that later by manually calling this handleURL method with the
+      // url it reads of the location. But it's important this is called
+      // first by Backbone, because we wanna set a correct this.path value
+      if (this.updateCallback) {
+        this.updateCallback(url);
+      }
+    },
+
+    formatURL: function (url) {
+      if (this.locationBar.hasPushState()) {
+        var rootURL = this.options.root;
+
+        if (url !== "") {
+          rootURL = rootURL.replace(/\/$/, '');
+        }
+
+        return rootURL + url;
+      } else {
+        if (url[0] === "/") {
+          url = url.substr(1);
+        }
+        return "#" + url;
+      }
+    },
+
+    destroy: function () {
+      this.locationBar.stop();
+    }
+  };
+
+  return HistoryLocation;
+});

--- a/util/extend.js
+++ b/util/extend.js
@@ -1,0 +1,8 @@
+define(function () {
+  return function extend(obj, source) {
+    for (var prop in source) {
+      obj[prop] = source[prop];
+    }
+    return obj;
+  };
+});


### PR DESCRIPTION
That's done via the location/history_location module that uses the
location-bar module to do the URL touching. history_location is an adapter
of location-bar to cherrytree.
