### PR TITLE
Improve example readme

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 node_modules
 sauce.json
 .sublimelinterrc
+examples/*/dist

--- a/examples/hello-world/README.md
+++ b/examples/hello-world/README.md
@@ -7,3 +7,5 @@ npm install
 npm run bundle
 npm start
 ```
+
+After running `npm start` you can navigate to default [localhost](http://localhost:8000/webpack-dev-server/bundle) to see the example.

--- a/examples/hello-world/README.md
+++ b/examples/hello-world/README.md
@@ -2,10 +2,11 @@
 
 This is a single file demo of cherrytree. It's a very simple static twitter like app. It's simple to keep the code short and just show how to get started.
 
-```
-npm install
-npm run bundle
-npm start
-```
+    $ npm install
+    $ npm start
 
-After running `npm start` you can navigate to default [localhost](http://localhost:8000/webpack-dev-server/bundle) to see the example.
+After running `npm start` you can navigate to default [http://localhost:8000/bundle](http://localhost:8000/bundle) to see the example.
+
+To compile the app into a single file for production run
+
+    $ npm run bundle

--- a/examples/hello-world/README.md
+++ b/examples/hello-world/README.md
@@ -4,5 +4,6 @@ This is a single file demo of cherrytree. It's a very simple static twitter like
 
 ```
 npm install
+npm run bundle
 npm start
 ```

--- a/examples/hello-world/package.json
+++ b/examples/hello-world/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "start": "webpack-dev-server --colors --no-info --port=8000 --content-base .",
-    "bundle" : "webpack --progress --colors",
+    "bundle" : "webpack --progress --colors -p",
     "test": "mocha"
   },
   "author": "",

--- a/examples/hello-world/package.json
+++ b/examples/hello-world/package.json
@@ -5,6 +5,7 @@
   "main": "index.js",
   "scripts": {
     "start": "webpack-dev-server --colors --no-info --port=8000 --content-base .",
+    "bundle" : "webpack --progress --colors",
     "test": "mocha"
   },
   "author": "",

--- a/examples/hello-world/webpack.config.js
+++ b/examples/hello-world/webpack.config.js
@@ -2,7 +2,7 @@ module.exports = {
   context: __dirname,
   entry: './index',
   output: {
-    path: '',
+    path: 'dist',
     filename: 'bundle.js'
   },
   devtool: 'source-map',


### PR DESCRIPTION
Continuation of #71. Closes #71.

The main think I wanted to change was to document http://localhost:8000/bundle instead of http://localhost:8000/webpack-dev-server/bundle, because the later hides URLs behind an iframe and cherrytree is best played with when you can see and change the URL.