### PR TITLE
Remove es6-promise dependency

### DIFF
--- a/lib/router.js
+++ b/lib/router.js
@@ -37,7 +37,7 @@ Cherrytree.prototype.initialize = function (options) {
   this.options = _.extend({
     interceptLinks: true,
     logError: true,
-    Promise: window.Promise
+    Promise: global.Promise
   }, options)
   this.log = createLogger(this.options.log)
   this.logError = createLogger(this.options.logError, true)
@@ -74,7 +74,7 @@ Cherrytree.prototype.map = function (routes) {
 
   eachBranch({routes: this.routes}, [], function (routes) {
     // concatenate the paths of the list of routes
-    var path = routes.reduce(function (memo, r) {
+    var path = _.reduce(routes, function (memo, r) {
       // reset if there's a leading slash, otherwise concat
       // and keep resetting the trailing slash
       return (r.path[0] === '/' ? r.path : memo + '/' + r.path).replace(/\/$/, '')

--- a/lib/router.js
+++ b/lib/router.js
@@ -42,9 +42,7 @@ Cherrytree.prototype.initialize = function (options) {
   this.log = createLogger(this.options.log)
   this.logError = createLogger(this.options.logError, true)
 
-  if (typeof this.options.Promise !== 'function') {
-    throw new Error('Cherrytree requires an ES6 Promise implementation, either as an explicit option or a global Promise')
-  }
+  invariant(typeof this.options.Promise === 'function', 'Cherrytree requires an ES6 Promise implementation, either as an explicit option or a global Promise')
 }
 
 /**

--- a/lib/router.js
+++ b/lib/router.js
@@ -36,10 +36,15 @@ Cherrytree.prototype.initialize = function (options) {
   this.middleware = []
   this.options = _.extend({
     interceptLinks: true,
-    logError: true
+    logError: true,
+    Promise: window.Promise
   }, options)
   this.log = createLogger(this.options.log)
   this.logError = createLogger(this.options.logError, true)
+
+  if (typeof this.options.Promise !== 'function') {
+    throw new Error('Cherrytree requires an ES6 Promise implementation, either as an explicit option or a global Promise')
+  }
 }
 
 /**
@@ -69,7 +74,7 @@ Cherrytree.prototype.map = function (routes) {
 
   eachBranch({routes: this.routes}, [], function (routes) {
     // concatenate the paths of the list of routes
-    var path = _.reduce(routes, function (memo, r) {
+    var path = routes.reduce(function (memo, r) {
       // reset if there's a leading slash, otherwise concat
       // and keep resetting the trailing slash
       return (r.path[0] === '/' ? r.path : memo + '/' + r.path).replace(/\/$/, '')
@@ -330,7 +335,7 @@ Cherrytree.prototype.dispatch = function (path) {
         match: match,
         noop: true,
         router: this
-      })
+      }, this.options.Promise)
     }
   }
 
@@ -339,7 +344,7 @@ Cherrytree.prototype.dispatch = function (path) {
     path: path,
     match: match,
     router: this
-  })
+  }, this.options.Promise)
 
   this.state.activeTransition = t
 

--- a/lib/transition.js
+++ b/lib/transition.js
@@ -1,9 +1,8 @@
 var _ = require('./dash')
-var Promise = require('es6-promise').Promise
 var invariant = require('./invariant')
 var Path = require('./path')
 
-module.exports = function transition (options) {
+module.exports = function transition (options, Promise) {
   options = options || {}
 
   let router = options.router

--- a/package.json
+++ b/package.json
@@ -19,7 +19,6 @@
     "url": "https://github.com/QubitProducts/cherrytree/issues"
   },
   "dependencies": {
-    "es6-promise": "^2.0.1",
     "location-bar": "^2.0.0",
     "lodash": "^3.3.0",
     "path-to-regexp": "^1.0.3",
@@ -41,6 +40,7 @@
     "bro-size": "^1.0.0",
     "cli-color": "^0.3.3",
     "co": "^4.5.1",
+    "es6-promise": "^2.0.1",
     "istanbul-instrumenter-loader": "^0.1.3",
     "jquery": "^2.1.3",
     "karma": "^0.13.3",


### PR DESCRIPTION
A promise implementation must be specified as an option now if no global Promise implementation exists.