### PR TITLE
Allow non-leaf nodes to be routable

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,6 @@ router.map(function (route) {
     route('messages')
     route('status', {path: ':user/status/:id'})
     route('profile', {path: ':user'}, function () {
-      route('profile.index')
       route('profile.lists')
       route('profile.edit')
     })
@@ -165,7 +164,6 @@ Configure the router with a route map. E.g.
 ```js
 router.map(function (route) {
   route('app', {path: '/'}, function () {
-    route('index')
     route('about')
     route('post', {path: ':postId'}, function () {
       route('show')

--- a/guide.md
+++ b/guide.md
@@ -16,7 +16,6 @@ Then use the `map` method to define the route map.
 ```js
 router.map(function(route) {
   route('application', { path: '/', handler: App }, function () {
-    route('index')
     route('about', { handler: About })
     route('favorites', { path: 'favs', handler: Favorites })
     route('message', { path: 'message/:id', handler: Message })
@@ -50,37 +49,17 @@ router.map(function(route) {
 });
 ```
 
-If the route is named 'index' or ends with '.index', the path defaults to '' and not the name of the route. For example, these are equivalent
-
-```js
-router.map(function(route) {
-  route('index')
-  route('profile', function () {
-    route('profile.index')
-  });
-});
-
-// or
-
-router.map(function(route) {
-  route('index', {path: ''})
-  route('profile', function () {
-    route('profile.index', {path: ''})
-  });
-});
-```
-
 To generate links to the different routes use `generate` and pass the name of the route:
 
 ```js
 router.generate('favorites')
 // => /favs
-router.generate('index');
+router.generate('application');
 // => /
 router.generate('messages', {id: 24});
 ```
 
-It's only possible to transition to or generate urls for leaf routes.
+You may opt out of a route being generated for a parent by setting `routeable: true` in the options.
 
 If you configure the HistoryLocation to use hashchange event (by setting `pushState: false`), the generated links will start with `#`.
 
@@ -111,11 +90,8 @@ Route nesting is one of the core features of cherrytree. It's useful to nest rou
 ```js
 router.map(function(route) {
   route('gmail', {path: '/'}, function () {
-    route('index')
     route('inbox', function() {
-      route('inbox.index')
       route('mail', {path: 'm/:mailId'}, function () {
-        route('mail.index')
         route('mail.raw')
       })
     })
@@ -135,14 +111,9 @@ This router creates the following routes:
     </tr>
     </thead>
     <tr>
-      <td><code>N/A</code></td>
-      <td><code>gmail</code></td>
-      <td>Initialize core app state and render the app layout</td>
-    </tr>
-    <tr>
       <td><code>/</code></td>
-      <td><code>index</code></td>
-      <td>Redirect to inbox.index</td>
+      <td><code>gmail</code></td>
+      <td>Redirect to inbox</td>
     </tr>
     <tr>
       <td>N/A</td>
@@ -150,19 +121,9 @@ This router creates the following routes:
       <td>Load 1 page of emails and render it</td>
     </tr>
     <tr>
-      <td>/inbox</td>
-      <td><code>inbox.index</code></td>
-      <td>The leaf route for index - this route doesn't need to do anything</td>
-    </tr>
-    <tr>
       <td>N/A</td>
       <td><code>mail</code></td>
       <td>Load the email contents of email with id `transition.params.mailId` and expand it in the list of emails while keeping the email list rendered</td>
-    </tr>
-    <tr>
-      <td><code>/inbox/m/:mailId</code></td>
-      <td><code>mail.index</code></td>
-      <td>Render the email content in the expanded pane</td>
     </tr>
     <tr>
       <td><code>/inbox/m/:mailId/raw</code></td>

--- a/guide.md
+++ b/guide.md
@@ -59,8 +59,6 @@ router.generate('application');
 router.generate('messages', {id: 24});
 ```
 
-You may opt out of a route being generated for a parent by setting `absract: true` in the options.
-
 If you configure the HistoryLocation to use hashchange event (by setting `pushState: false`), the generated links will start with `#`.
 
 ### Route params

--- a/guide.md
+++ b/guide.md
@@ -59,7 +59,7 @@ router.generate('application');
 router.generate('messages', {id: 24});
 ```
 
-You may opt out of a route being generated for a parent by setting `routeable: true` in the options.
+You may opt out of a route being generated for a parent by setting `absract: true` in the options.
 
 If you configure the HistoryLocation to use hashchange event (by setting `pushState: false`), the generated links will start with `#`.
 

--- a/lib/dsl.js
+++ b/lib/dsl.js
@@ -25,9 +25,6 @@ export default function dsl (callback) {
     if (typeof options.path !== 'string') {
       let parts = name.split('.')
       options.path = parts[parts.length - 1]
-      if (options.path === 'index') {
-        options.path = ''
-      }
     }
 
     // go to the next level

--- a/lib/router.js
+++ b/lib/router.js
@@ -79,9 +79,7 @@ Cherrytree.prototype.map = function (routes) {
 
   function eachBranch (node, memo, fn) {
     node.routes.forEach(function (route) {
-      if (!route.options || route.options.abstract !== true) {
-        fn(memo.concat(route))
-      }
+      fn(memo.concat(route))
       if (route.routes && route.routes.length > 0) {
         eachBranch(route, memo.concat(route), fn)
       }

--- a/lib/router.js
+++ b/lib/router.js
@@ -79,9 +79,10 @@ Cherrytree.prototype.map = function (routes) {
 
   function eachBranch (node, memo, fn) {
     node.routes.forEach(function (route) {
-      if (!route.routes || route.routes.length === 0) {
+      if (!route.options || route.options.routable !== false) {
         fn(memo.concat(route))
-      } else {
+      }
+      if (route.routes && route.routes.length > 0) {
         eachBranch(route, memo.concat(route), fn)
       }
     })

--- a/lib/router.js
+++ b/lib/router.js
@@ -79,7 +79,7 @@ Cherrytree.prototype.map = function (routes) {
 
   function eachBranch (node, memo, fn) {
     node.routes.forEach(function (route) {
-      if (!route.options || route.options.routable !== false) {
+      if (!route.options || route.options.abstract !== true) {
         fn(memo.concat(route))
       }
       if (route.routes && route.routes.length > 0) {

--- a/tests/functional/pushStateTest.js
+++ b/tests/functional/pushStateTest.js
@@ -8,7 +8,6 @@ let app, router, history
 
 // This is to avoid running these tests in IE9 in CI
 if (window.history && window.history.pushState) {
-
   suite('Cherrytree app using pushState')
 
   beforeEach(() => {
@@ -47,5 +46,4 @@ if (window.history && window.history.pushState) {
     yield router.transitionTo('faq', {}, { sortBy: 'user' })
     assert.equals($('.application .outlet').html(), 'FAQ. Sorted By: user')
   }))
-
 }

--- a/tests/functional/routerTest.js
+++ b/tests/functional/routerTest.js
@@ -55,7 +55,7 @@ test('cancelling and retrying transitions', co.wrap(function * () {
 test('transition.followRedirects resolves when all of the redirects have finished', co.wrap(function * () {
   var transition
 
-  yield router.transitionTo('index')
+  yield router.transitionTo('application')
   // initiate a transition
   transition = router.transitionTo('/posts/filter/foo')
   // and a redirect
@@ -66,7 +66,7 @@ test('transition.followRedirects resolves when all of the redirects have finishe
   yield transition.catch(() => rejected = true)
   assert(rejected)
 
-  yield router.transitionTo('index')
+  yield router.transitionTo('application')
   // initiate a transition
   var t = router.transitionTo('/posts/filter/foo')
   // and a redirect, this time using `redirectTo`

--- a/tests/functional/testApp.js
+++ b/tests/functional/testApp.js
@@ -10,7 +10,6 @@ export default function TestApp (options) {
   // provide the route map
   router.map(function (route) {
     route('application', { path: '/' }, function () {
-      route('index')
       route('about')
       route('faq')
       route('posts', function () {
@@ -37,13 +36,8 @@ export default function TestApp (options) {
       })
       this.$view.html('<h1>Cherrytree Application</h1><div class="outlet"></div>')
       this.$outlet = this.$view.find('.outlet')
+      this.$outlet.html('Welcome to this application')
       $(document.body).html(this.$view)
-    }
-  }
-
-  handlers['index'] = {
-    activate: function () {
-      this.parent.$outlet.html('Welcome to this application')
     }
   }
 

--- a/tests/unit/linksTest.js
+++ b/tests/unit/linksTest.js
@@ -29,7 +29,10 @@ test('intercepts link clicks', () => {
   // the navigation, we must install this after the
   // link.intercept has been already called
   let navPreventedCount = 0
-  $(document).on('click', e => {navPreventedCount++; e.preventDefault()})
+  $(document).on('click', e => {
+    navPreventedCount++
+    e.preventDefault()
+  })
 
   // now test that when clicking the link, the calledWith
   mouse.click($a.get(0))

--- a/tests/unit/routerTest.js
+++ b/tests/unit/routerTest.js
@@ -333,16 +333,16 @@ test('a complex route map', () => {
   ])
 })
 
-test('a parent route can be excluded from the route map by setting routable to false', () => {
+test('a parent route can be excluded from the route map by setting abstract to true', () => {
   router.map((route) => {
-    route('application', { routable: false }, () => {
+    route('application', { abstract: true }, () => {
       route('notifications')
       route('messages', () => {
         route('unread', () => {
           route('priority')
         })
         route('read')
-        route('draft', { routable: false }, () => {
+        route('draft', { abstract: true }, () => {
           route('recent')
         })
       })

--- a/tests/unit/routerTest.js
+++ b/tests/unit/routerTest.js
@@ -333,39 +333,6 @@ test('a complex route map', () => {
   ])
 })
 
-test('a parent route can be excluded from the route map by setting abstract to true', () => {
-  router.map((route) => {
-    route('application', { abstract: true }, () => {
-      route('notifications')
-      route('messages', () => {
-        route('unread', () => {
-          route('priority')
-        })
-        route('read')
-        route('draft', { abstract: true }, () => {
-          route('recent')
-        })
-      })
-      route('status', {path: ':user/status/:id'})
-    })
-    route('anotherTopLevel', () => {
-      route('withChildren')
-    })
-  })
-
-  assert.equals(router.matchers.map(m => m.path), [
-    '/application/notifications',
-    '/application/messages',
-    '/application/messages/unread',
-    '/application/messages/unread/priority',
-    '/application/messages/read',
-    '/application/messages/draft/recent',
-    '/application/:user/status/:id',
-    '/anotherTopLevel',
-    '/anotherTopLevel/withChildren'
-  ])
-})
-
 test('routes with duplicate names throw a useful error', () => {
   try {
     router.map((route) => {


### PR DESCRIPTION
Currently in cherrytree, if you want `forums/1` to be routable, and `forums/1/posts/2` to be routable, you need to create a separate leaf node for `forums/1` that is *not* in the hiarchy of `forums/1/posts/2`, despite these being clear children in the URL. This poses two big problems:

1. Unintuititive and repetative. This caught me off guard that routes for parents were not generated, and I had to repeat myself by doing another route call with `.index` on and repeating options passed in (in `cherrytree-for-knockout`'s case, this is the knockout component that is specified twice and registered twice).
2. the DOM of the extra leaf node is destroyed and rerendered, klling intermediate state like scroll positions and widgets not aware of cherrytree, and causing flicker. If I have any chrome around `forums/1` it will be destroyed because there is no linkage declared between `forums/1` route and `forums/1/params/2` without going out of my way to crawl all the routes and comparing the real URLs.

It is a breaking change to register these by default (though it's still alpha, so it seems fine). I highly recommend it, but I could concede to have it be an explicit opt in. One option is to register these by default only if any options are specified for parent routes.

Also I am not quite sure on the naming of an option to opt out of a parent route having a route generated for it. `route`, `navigatable`, or `abstract` came to mind but didn't seem as good as `routable`. 