### PR TITLE
Refer to the global Promise without using `global`

### DIFF
--- a/lib/router.js
+++ b/lib/router.js
@@ -23,7 +23,7 @@ Cherrytree.prototype.initialize = function (options) {
   this.options = extend({
     interceptLinks: true,
     logError: true,
-    Promise: global.Promise
+    Promise: Promise
   }, options)
   this.log = createLogger(this.options.log)
   this.logError = createLogger(this.options.logError, { error: true })


### PR DESCRIPTION
Otherwise it throws in standalone build, it seems