### PR TITLE
Remove qs dependency, instead provide a very simple query string parser

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,7 @@ To use `cherrytree` with React, check out [`cherrytree-for-react`](https://githu
 * **options.pushState** - default is false, which means using hashchange events. Set to `true` to use pushState.
 * **options.root** - default is `/`. Use in combination with `pushState: true` if your application is not being served from the root url /.
 * **options.interceptLinks** - default is true. When pushState is used - intercepts all link clicks when appropriate, prevents the default behaviour and instead uses pushState to update the URL and handle the transition via the router. Read more on [intercepting links below](#intercepting-links).
+* **options.qs** - default is a simple built in query string parser. Pass in an object with `parse` and `stringify` functions to customize how query strings get treated.
 * **options.Promise** - default is window.Promise or global.Promise. Promise implementation to be used when constructing transitions.
 
 ### router.map(fn)
@@ -303,6 +304,17 @@ It generates a URL with # if router is in hashChange mode and with no # if route
 ### router.state
 
 The state of the route is always available on the `router.state` object. It contains `activeTransition`, `routes`, `path`, `pathname`, `params` and `query`.
+
+## Query params
+
+Cherrytree will extract and parse the query params using a very simple query string parser that only supports key values. For example, `?a=1&b=2` will be parsed to `{a: 1, b:2}`. If you want to use a more sophisticated query parser, pass in an object with `parse` and `stringify` functions - an interface compatible with the popular [qs](https://github.com/hapijs/qs) module e.g.:
+
+```js
+cherrytree({
+  qs: require('qs')
+})
+```
+
 
 ## Errors
 

--- a/lib/path.js
+++ b/lib/path.js
@@ -1,6 +1,4 @@
 import invariant from './invariant'
-import qs from 'qs'
-import { merge } from 'qs/lib/utils'
 import pathToRegexp from 'path-to-regexp'
 
 let paramInjectMatcher = /:([a-zA-Z_$][a-zA-Z0-9_$?]*[?+*]?)/g
@@ -100,29 +98,16 @@ let Path = {
    * Returns an object that is the result of parsing any query string contained
    * in the given path, null if the path contains no query string.
    */
-  extractQuery: function (path) {
+  extractQuery: function (qs, path) {
     let match = path.match(queryMatcher)
     return match && qs.parse(match[1])
-  },
-
-  /**
-   * Returns a version of the given path without the query string.
-   */
-  withoutQuery: function (path) {
-    return path.replace(queryMatcher, '')
   },
 
   /**
    * Returns a version of the given path with the parameters in the given
    * query merged into the query string.
    */
-  withQuery: function (path, query) {
-    let existingQuery = Path.extractQuery(path)
-
-    if (existingQuery) {
-      query = query ? merge(existingQuery, query) : existingQuery
-    }
-
+  withQuery: function (qs, path, query) {
     let queryString = qs.stringify(query, { indices: false })
 
     if (queryString) {
@@ -130,6 +115,13 @@ let Path = {
     }
 
     return path
+  },
+
+  /**
+   * Returns a version of the given path without the query string.
+   */
+  withoutQuery: function (path) {
+    return path.replace(queryMatcher, '')
   }
 }
 

--- a/lib/qs.js
+++ b/lib/qs.js
@@ -1,0 +1,15 @@
+export default {
+  parse (querystring) {
+    return querystring.split('&').reduce((acc, pair) => {
+      let parts = pair.split('=')
+      acc[parts[0]] = decodeURIComponent(parts[1])
+      return acc
+    }, {})
+  },
+
+  stringify (params) {
+    return Object.keys(params).reduce((acc, key) => {
+      return acc + key + '=' + encodeURIComponent(params[key])
+    }, '')
+  }
+}

--- a/lib/router.js
+++ b/lib/router.js
@@ -7,6 +7,7 @@ import MemoryLocation from './locations/memory'
 import transition from './transition'
 import { intercept } from './links'
 import createLogger from './logger'
+import qs from './qs'
 
 function Cherrytree () {
   this.initialize.apply(this, arguments)
@@ -24,7 +25,8 @@ Cherrytree.prototype.initialize = function (options) {
     location: 'history',
     interceptLinks: true,
     logError: true,
-    Promise: Promise
+    Promise: Promise,
+    qs: qs
   }, options)
   this.log = createLogger(this.options.log)
   this.logError = createLogger(this.options.logError, { error: true })
@@ -188,7 +190,7 @@ Cherrytree.prototype.generate = function (name, params, query) {
   }
   params = extend(currentParams, params)
 
-  let url = Path.withQuery(Path.injectParams(matcher.path, params), query)
+  let url = Path.withQuery(this.options.qs, Path.injectParams(matcher.path, params), query)
   return this.location.formatURL(url)
 }
 
@@ -254,13 +256,14 @@ Cherrytree.prototype.match = function (path) {
   let query
   let routes = []
   let pathWithoutQuery = Path.withoutQuery(path)
+  let qs = this.options.qs
   this.matchers.forEach(function (matcher) {
     if (!found) {
       params = Path.extractParams(matcher.path, pathWithoutQuery)
       if (params) {
         found = true
         routes = matcher.routes
-        query = Path.extractQuery(path) || {}
+        query = Path.extractQuery(qs, path) || {}
       }
     }
   })

--- a/package.json
+++ b/package.json
@@ -20,8 +20,7 @@
   },
   "dependencies": {
     "location-bar": "^2.0.0",
-    "path-to-regexp": "^1.0.3",
-    "qs": "^2.3.3"
+    "path-to-regexp": "^1.0.3"
   },
   "keywords": [
     "router",

--- a/tests/unit/pathTest.js
+++ b/tests/unit/pathTest.js
@@ -1,4 +1,5 @@
 import { assert } from 'referee'
+import qs from '../../lib/qs'
 import Path from '../../lib/path'
 
 let {suite, test} = window
@@ -91,10 +92,9 @@ test('Path.injectParams', () => {
 })
 
 test('Path.extractQuery', () => {
-  assert.equals(Path.extractQuery('/?id=def&show=true'), { id: 'def', show: 'true' })
-  assert.equals(Path.extractQuery('/?id%5B%5D=a&id%5B%5D=b'), { id: [ 'a', 'b' ] })
-  assert.equals(Path.extractQuery('/?id=a%26b'), { id: 'a&b' })
-  assert.equals(Path.extractQuery('/a/b/c'), null)
+  assert.equals(Path.extractQuery(qs, '/?id=def&show=true'), { id: 'def', show: 'true' })
+  assert.equals(Path.extractQuery(qs, '/?id=a%26b'), { id: 'a&b' })
+  assert.equals(Path.extractQuery(qs, '/a/b/c'), null)
 })
 
 test('Path.withoutQuery', () => {
@@ -102,7 +102,6 @@ test('Path.withoutQuery', () => {
 })
 
 test('Path.withQuery', () => {
-  assert.equals(Path.withQuery('/a/b/c', { id: 'def' }), '/a/b/c?id=def')
-  assert.equals(Path.withQuery('/path?a=b', { c: [ 'd', 'e' ] }), '/path?a=b&c=d&c=e')
-  assert.equals(Path.withQuery('/path?a=b', { c: [ 'd#e', 'f&a=i#j+k' ] }), '/path?a=b&c=d%23e&c=f%26a%3Di%23j%2Bk')
+  assert.equals(Path.withQuery(qs, '/a/b/c', { id: 'def' }), '/a/b/c?id=def')
+  assert.equals(Path.withQuery(qs, '/path?a=b', { c: 'f&a=i#j+k' }), '/path?c=f%26a%3Di%23j%2Bk')
 })


### PR DESCRIPTION
And make qs configurable, e.g.

```
cherrytree({
  qs: require('qs')
})
```

Basically, there is no need to assume that app will use query strings or not, and if it does - it's very simple to plug in `qs` or any other query string parser.

- [x] Update README