### PR TITLE
Export Browser and Memory locations in the main module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### v2.0.0-rc4
+
+* BrowserLocation and HistoryLocation can now be accessed at cherrytree.BrowserLocation and cherrytree.MemoryLocation again. This is to make it easier to use those modules for UMD users (#116).
+
 ### v2.0.0-rc3
 
 Breaking changes:

--- a/lib/router.js
+++ b/lib/router.js
@@ -389,3 +389,6 @@ Cherrytree.prototype.interceptLinks = function () {
 export default function cherrytree (options) {
   return new Cherrytree(options)
 }
+
+cherrytree.BrowserLocation = BrowserLocation
+cherrytree.MemoryLocation = MemoryLocation

--- a/tests/unit/routerTest.js
+++ b/tests/unit/routerTest.js
@@ -1,5 +1,6 @@
 import { assert } from 'referee'
 import BrowserLocation from '../../lib/locations/browser'
+import MemoryLocation from '../../lib/locations/memory'
 import { extend } from '../../lib/dash'
 import cherrytree from '../..'
 
@@ -418,3 +419,8 @@ if (window.history && window.history.pushState) {
     document.body.removeChild(a)
   })
 }
+
+test('Browser and Memory locations are exported in the main router file', function () {
+  assert.equals(cherrytree.BrowserLocation, BrowserLocation)
+  assert.equals(cherrytree.MemoryLocation, MemoryLocation)
+})


### PR DESCRIPTION
This is mostly for UMD users that want to be able to access
Browser and Memory locations when using the standalone build