### PR TITLE
Always parse query string parameters when attempting to match a route

### DIFF
--- a/lib/router.js
+++ b/lib/router.js
@@ -258,7 +258,6 @@ Cherrytree.prototype.match = function (path) {
   path = (path || '').replace(/\/$/, '') || '/'
   let found = false
   let params
-  let query
   let routes = []
   let pathWithoutQuery = Path.withoutQuery(path)
   let qs = this.options.qs
@@ -268,14 +267,13 @@ Cherrytree.prototype.match = function (path) {
       if (params) {
         found = true
         routes = matcher.routes
-        query = Path.extractQuery(qs, path) || {}
       }
     }
   })
   return {
     routes: routes.map(descriptor),
     params: params || {},
-    query: query || {}
+    query: Path.extractQuery(qs, path) || {}
   }
 
   // clone the data (only a shallow clone of options)

--- a/tests/unit/routerTest.js
+++ b/tests/unit/routerTest.js
@@ -265,6 +265,12 @@ test('#match returns an empty route array if nothing matches', () => {
   assert.equals(match, {routes: [], params: {}, query: {}})
 })
 
+test('#match always parses query parameters even if a route does not match', () => {
+  router.map(routes)
+  let match = router.match('/foo/bar?hello=world')
+  assert.equals(match, {routes: [], params: {}, query: { hello: 'world' }})
+})
+
 test('#transitionTo called multiple times reuses the active transition', (done) => {
   router.map(routes)
   router.listen().then(() => {


### PR DESCRIPTION
I was writing some middleware and surprised that query string parameters were not being parsed when a route wasn't matching. I don't see a good reason not too, and lots of reasons too - middleware that is agnostic to route definitions may be looking for query string parameters.