### PR TITLE
strip slashes from the end of generated url

### DIFF
--- a/lib/locations/browser.js
+++ b/lib/locations/browser.js
@@ -82,6 +82,7 @@ BrowserLocation.prototype.formatURL = function (path) {
     let rootURL = this.options.root
     if (path !== '') {
       rootURL = rootURL.replace(/\/$/, '')
+      path = path.replace(/\/+$/, '')
     }
     return rootURL + path
   } else {


### PR DESCRIPTION
paths like /path/:a?/:b?/:c? and no parameters, generates /path///