### PR TITLE
strip slashes from the end of generated url #2

### DIFF
--- a/lib/path.js
+++ b/lib/path.js
@@ -74,7 +74,7 @@ let Path = {
   injectParams: function (pattern, params) {
     params = params || {}
 
-    return pattern.replace(paramInjectMatcher, function (match, param) {
+    var path = pattern.replace(paramInjectMatcher, function (match, param) {
       let paramName = param.replace(specialParamChars, '')
 
       // If param is optional don't check for existence
@@ -91,7 +91,15 @@ let Path = {
       }
 
       return params[paramName]
-    })
+    });
+    
+    path = path.replace(/\/+$/,'');
+    
+    if(path == '') {
+      return '/';
+    }
+    
+    return path;
   },
 
   /**

--- a/lib/path.js
+++ b/lib/path.js
@@ -91,15 +91,15 @@ let Path = {
       }
 
       return params[paramName]
-    });
-    
-    path = path.replace(/\/+$/,'');
-    
-    if(path == '') {
-      return '/';
+    })
+
+    path = path.replace(/\/+$/, '')
+
+    if (path === '') {
+      return '/'
     }
-    
-    return path;
+
+    return path
   },
 
   /**

--- a/tests/unit/pathTest.js
+++ b/tests/unit/pathTest.js
@@ -82,7 +82,7 @@ test('Path.injectParams', () => {
 
   assert.equals(Path.injectParams('/a/:foo*/d', { foo: 'b/c' }), '/a/b/c/d')
   assert.equals(Path.injectParams('/a/:foo*/c/:bar*', { foo: 'b', bar: 'd' }), '/a/b/c/d')
-  assert.equals(Path.injectParams('/a/:foo*/c/:bar*', { foo: 'b' }), '/a/b/c/')
+  assert.equals(Path.injectParams('/a/:foo*/c/:bar*', { foo: 'b' }), '/a/b/c')
 
   assert.equals(Path.injectParams('/a/:foo+/d', { foo: 'b/c' }), '/a/b/c/d')
   assert.equals(Path.injectParams('/a/:foo+/c/:bar+', { foo: 'b', bar: 'd' }), '/a/b/c/d')


### PR DESCRIPTION
paths like /path/:a?/:b?/:c? with no parameters, generates /path///
and causing error "TypeError: Cannot read property 'options' of undefined"

second try :)
