### PR TITLE
Add isActive function to router

### DIFF
--- a/lib/router.js
+++ b/lib/router.js
@@ -233,15 +233,9 @@ Cherrytree.prototype.isActive = function (name, params, query) {
   let activeParams = this.state.params || {}
   let activeQuery = this.state.query || []
 
-  let isNameActive = !!activeRoutes.find((route) => {
-    return route.name === name
-  })
-  let areParamsActive = !!Object.keys(params).every((key) => {
-    return activeParams[key] === params[key]
-  })
-  let isQueryActive = !!Object.keys(query).every((key) => {
-    return activeQuery[key] === query[key]
-  })
+  let isNameActive = !!activeRoutes.find(route => route.name === name)
+  let areParamsActive = !!Object.keys(params).every(key => activeParams[key] === params[key])
+  let isQueryActive = !!Object.keys(query).every(key => activeQuery[key] === query[key])
 
   return isNameActive && areParamsActive && isQueryActive
 }

--- a/lib/router.js
+++ b/lib/router.js
@@ -229,7 +229,9 @@ Cherrytree.prototype.isActive = function (name, params, query) {
   params = params || {}
   query = query || {}
 
-  let { routes: activeRoutes, params: activeParams, query: activeQuery } = this.state
+  let activeRoutes = this.state.routes || []
+  let activeParams = this.state.params || {}
+  let activeQuery = this.state.query || []
 
   let isNameActive = !!activeRoutes.find((route) => {
     return route.name === name

--- a/lib/router.js
+++ b/lib/router.js
@@ -217,6 +217,34 @@ Cherrytree.prototype.destroy = function () {
 }
 
 /**
+ * Check if the given route/params/query combo is active
+ * @param  {String} name   target route name
+ * @param  {Object} params
+ * @param  {Object} query
+ * @return {Boolean}
+ *
+ * @api public
+ */
+Cherrytree.prototype.isActive = function (name, params, query) {
+  params = params || {}
+  query = query || {}
+
+  let { routes: activeRoutes, params: activeParams, query: activeQuery } = this.state
+
+  let isNameActive = !!activeRoutes.find((route) => {
+    return route.name === name
+  })
+  let areParamsActive = !!Object.keys(params).every((key) => {
+    return activeParams[key] === params[key]
+  })
+  let isQueryActive = !!Object.keys(query).every((key) => {
+    return activeQuery[key] === query[key]
+  })
+
+  return isNameActive && areParamsActive && isQueryActive
+}
+
+/**
  * @api private
  */
 Cherrytree.prototype.doTransition = function (method, params) {

--- a/tests/unit/routerTest.js
+++ b/tests/unit/routerTest.js
@@ -297,6 +297,27 @@ test('#transitionTo called on the same route, returns a completed transition', (
   }).catch(done)
 })
 
+test('#isActive returns true if arguments match current state and false if not', (done) => {
+  router.map(routes)
+  router.listen().then(() => {
+    return router.transitionTo('notifications')
+  }).then(() => {
+    assert.equals(router.isActive('notifications'), true)
+    assert.equals(router.isActive('messages'), false)
+  }).then(() => {
+    return router.transitionTo('status', {user: 'me', id: 1})
+  }).then(() => {
+    assert.equals(router.isActive('status', {user: 'me'}), true)
+    assert.equals(router.isActive('status', {user: 'notme'}), false)
+  }).then(() => {
+    return router.transitionTo('messages', null, {foo: 'bar'})
+  }).then(() => {
+    assert.equals(router.isActive('messages', null, {foo: 'bar'}), true)
+    assert.equals(router.isActive('messages', null, {foo: 'baz'}), false)
+    done()
+  }).catch(done)
+})
+
 suite('route maps')
 
 beforeEach(() => {


### PR DESCRIPTION
Closes #132 

Adds an isActive function that allows you to easily assert whether a name/params/query combo is active.