### PR TITLE
Remove redundant code from Cherrytree.prototype.map

### DIFF
--- a/lib/router.js
+++ b/lib/router.js
@@ -75,15 +75,17 @@ Cherrytree.prototype.map = function (routes) {
     if (path === '') {
       path = '/'
     }
+
+    let lastRoute = routes[routes.length - 1]
+
     // register routes
     matchers.push({
       routes: routes,
-      name: routes[routes.length - 1].name,
+      name: lastRoute.name,
       path: path
     })
 
     // dupe detection
-    let lastRoute = routes[routes.length - 1]
     if (dupes[path]) {
       throw new Error('Routes ' + dupes[path] + ' and ' + lastRoute.name +
       ' have the same url path \'' + path + '\'')
@@ -93,17 +95,13 @@ Cherrytree.prototype.map = function (routes) {
 
   function eachBranch (node, memo, fn) {
     node.routes.forEach(function (route) {
-      if (!abstract(route)) {
+      if (!route.options.abstract) {
         fn(memo.concat(route))
       }
-      if (route.routes && route.routes.length > 0) {
+      if (route.routes.length) {
         eachBranch(route, memo.concat(route), fn)
       }
     })
-  }
-
-  function abstract (route) {
-    return route.options && route.options.abstract
   }
 
   return this


### PR DESCRIPTION
This PR removes some redundant code

 * Assign lastRoute var earlier so it can be used in matcher object
 * Remove check for route.options and abstract function since options property is normalized / created unconditionally in dsl
 * Remove check for route.routes since routes property is created unconditionally in dsl



