### PR TITLE
Minor optimization for Cherrytree.dispatch 

### DIFF
--- a/lib/router.js
+++ b/lib/router.js
@@ -280,23 +280,21 @@ Cherrytree.prototype.doTransition = function (method, params) {
  */
 Cherrytree.prototype.match = function (path) {
   path = (path || '').replace(/\/$/, '') || '/'
-  let found = false
   let params
   let routes = []
   let pathWithoutQuery = Path.withoutQuery(path)
   let qs = this.options.qs
-  this.matchers.forEach(function (matcher) {
-    if (!found) {
-      params = Path.extractParams(matcher.path, pathWithoutQuery)
-      if (params) {
-        found = true
-        routes = matcher.routes
-      }
+  this.matchers.some(function (matcher) {
+    params = Path.extractParams(matcher.path, pathWithoutQuery)
+    if (params) {
+      routes = matcher.routes
+      return true
     }
   })
   return {
     routes: routes.map(descriptor),
     params: params || {},
+    pathname: pathWithoutQuery,
     query: Path.extractQuery(qs, path) || {}
   }
 
@@ -319,7 +317,7 @@ Cherrytree.prototype.match = function (path) {
 Cherrytree.prototype.dispatch = function (path) {
   let match = this.match(path)
   let query = match.query
-  let pathname = Path.withoutQuery(path)
+  let pathname = match.pathname
 
   let activeTransition = this.state.activeTransition
 

--- a/lib/transition.js
+++ b/lib/transition.js
@@ -1,6 +1,5 @@
 import { clone } from './dash'
 import invariant from './invariant'
-import Path from './path'
 
 export default function transition (options, Promise) {
   options = options || {}
@@ -13,6 +12,7 @@ export default function transition (options, Promise) {
   let match = options.match
   let routes = match.routes
   let params = match.params
+  let pathname = match.pathname
   let query = match.query
 
   let id = options.id
@@ -56,7 +56,7 @@ export default function transition (options, Promise) {
     },
     routes: clone(routes),
     path: path,
-    pathname: Path.withoutQuery(path),
+    pathname: pathname,
     params: clone(params),
     query: clone(query),
     redirectTo: function () {
@@ -137,7 +137,7 @@ export default function transition (options, Promise) {
         activeTransition: null,
         routes: routes,
         path: path,
-        pathname: Path.withoutQuery(path),
+        pathname: pathname,
         params: params,
         query: query
       }

--- a/tests/unit/routerTest.js
+++ b/tests/unit/routerTest.js
@@ -262,13 +262,13 @@ test('#match ignores the trailing slash', () => {
 test('#match returns an empty route array if nothing matches', () => {
   router.map(routes)
   let match = router.match('/foo/bar')
-  assert.equals(match, {routes: [], params: {}, query: {}})
+  assert.equals(match, {routes: [], params: {}, pathname: '/foo/bar', query: {}})
 })
 
 test('#match always parses query parameters even if a route does not match', () => {
   router.map(routes)
   let match = router.match('/foo/bar?hello=world')
-  assert.equals(match, {routes: [], params: {}, query: { hello: 'world' }})
+  assert.equals(match, {routes: [], params: {}, pathname: '/foo/bar', query: { hello: 'world' }})
 })
 
 test('#transitionTo called multiple times reuses the active transition', (done) => {


### PR DESCRIPTION
This PR does the following optimizations:
 * Returns pathname in match and use alongside the `dispatch` code path preventing `Path.withoutQuery` being called more than once
 * Use some instead of forEach in `match` to break loop earlier and allow remove of `found` var