### PR TITLE
Refactor Cherrytree.isActive to take advantage of boolean short-circuit evaluation

### DIFF
--- a/lib/router.js
+++ b/lib/router.js
@@ -229,13 +229,13 @@ Cherrytree.prototype.isActive = function (name, params, query) {
 
   let activeRoutes = this.state.routes || []
   let activeParams = this.state.params || {}
-  let activeQuery = this.state.query || []
+  let activeQuery = this.state.query || {}
 
-  let isNameActive = !!find(activeRoutes, route => route.name === name)
-  let areParamsActive = !!Object.keys(params).every(key => activeParams[key] === params[key])
-  let isQueryActive = !!Object.keys(query).every(key => activeQuery[key] === query[key])
+  let isActive = !!find(activeRoutes, route => route.name === name)
+  isActive = isActive && !!Object.keys(params).every(key => activeParams[key] === params[key])
+  isActive = isActive && !!Object.keys(query).every(key => activeQuery[key] === query[key])
 
-  return isNameActive && areParamsActive && isQueryActive
+  return isActive
 }
 
 /**


### PR DESCRIPTION
Instead of always evaluating condition of name, params and query, check for the previous value before evaluating

This will prevent evaluation, e.g., of params and query when name is not active

It also fixes a typo in activeQuery fallback value