### PR TITLE
Update dsl.js

### DIFF
--- a/lib/dsl.js
+++ b/lib/dsl.js
@@ -4,14 +4,9 @@ import invariant from './invariant'
 export default function dsl (callback) {
   let ancestors = []
   let matches = {}
-  let names = {}
 
   callback(function route (name, options, callback) {
     let routes
-
-    invariant(!names[name], 'Route names must be unique, but route "%s" is declared multiple times', name)
-
-    names[name] = true
 
     if (arguments.length === 1) {
       options = {}


### PR DESCRIPTION
"Route names must be unique, but route "%s" is declared multiple times" error feature working incorrectly and removed.

Not obligatory to give this error. The user must already know.