### PR TITLE
Make an abstract route with a child index route (path === '') matches its index route

### DIFF
--- a/lib/router.js
+++ b/lib/router.js
@@ -63,6 +63,8 @@ Cherrytree.prototype.map = function (routes) {
   // keep track of whether duplicate paths have been created,
   // in which case we'll warn the dev
   let dupes = {}
+  // keep track of abstract routes to build index route forwarding
+  let abstracts = {}
 
   eachBranch({routes: this.routes}, [], function (routes) {
     // concatenate the paths of the list of routes
@@ -77,6 +79,11 @@ Cherrytree.prototype.map = function (routes) {
     }
 
     let lastRoute = routes[routes.length - 1]
+
+    if (lastRoute.options.abstract) {
+      abstracts[path] = lastRoute.name
+      return
+    }
 
     // register routes
     matchers.push({
@@ -93,11 +100,29 @@ Cherrytree.prototype.map = function (routes) {
     dupes[path] = lastRoute.name
   })
 
+  // check if there is an index route for each abstract route
+  Object.keys(abstracts).forEach(function (path) {
+    let matcher
+    if (!dupes[path]) return
+
+    matchers.some(function (m) {
+      if (m.path === path) {
+        matcher = m
+        return true
+      }
+    })
+
+    matchers.push({
+      routes: matcher.routes,
+      name: abstracts[path],
+      path: path
+    })
+  })
+
   function eachBranch (node, memo, fn) {
     node.routes.forEach(function (route) {
-      if (!route.options.abstract) {
-        fn(memo.concat(route))
-      }
+      fn(memo.concat(route))
+
       if (route.routes.length) {
         eachBranch(route, memo.concat(route), fn)
       }

--- a/tests/unit/routerTest.js
+++ b/tests/unit/routerTest.js
@@ -168,6 +168,27 @@ test('#generate throws a useful error when listen has not been called', () => {
   }
 })
 
+test('#generate throws a useful error when called with an abstract route', () => {
+  router.map((route) => {
+    route('foo', {abstract: true})
+  }).listen()
+  try {
+    router.generate('foo')
+  } catch (err) {
+    assert.equals(err.message, 'No route is named foo')
+  }
+})
+
+test('#generate succeeds when called with an abstract route that has a child index route', () => {
+  router.map((route) => {
+    route('foo', {abstract: true}, () => {
+      route('bar', {path: ''})
+    })
+  }).listen()
+  let url = router.generate('foo')
+  assert.equals(url, '#foo')
+})
+
 test('#use middleware can not modify routers internal state by changing transition.routes', (done) => {
   window.location.hash = '/application/messages'
   router.map(routes)
@@ -295,6 +316,30 @@ test('#transitionTo called on the same route, returns a completed transition', (
     assert.equals(called, false)
     done()
   }).catch(done)
+})
+
+test('#transitionTo throws a useful error when called with an abstract route', () => {
+  router.map((route) => {
+    route('foo', {abstract: true})
+  }).listen()
+  try {
+    router.transitionTo('foo')
+  } catch (err) {
+    assert.equals(err.message, 'No route is named foo')
+  }
+})
+
+test('#transitionTo called on an abstract route with a child index route should activate the index route', async () => {
+  router.map((route) => {
+    route('foo', {abstract: true}, () => {
+      route('bar', {path: ''})
+    })
+  }).listen()
+  await router.transitionTo('foo')
+  assert.equals(router.isActive('foo'), true)
+  assert.equals(router.isActive('bar'), true)
+  assert.equals(router.state.routes.length, 2)
+  assert.equals(router.state.path, '/foo')
 })
 
 test('#isActive returns true if arguments match current state and false if not', async () => {

--- a/tests/unit/routerTest.js
+++ b/tests/unit/routerTest.js
@@ -172,11 +172,10 @@ test('#generate throws a useful error when called with an abstract route', () =>
   router.map((route) => {
     route('foo', {abstract: true})
   }).listen()
-  try {
+
+  assert.exception(function () {
     router.generate('foo')
-  } catch (err) {
-    assert.equals(err.message, 'No route is named foo')
-  }
+  }, {message: 'No route is named foo'})
 })
 
 test('#generate succeeds when called with an abstract route that has a child index route', () => {
@@ -318,15 +317,14 @@ test('#transitionTo called on the same route, returns a completed transition', (
   }).catch(done)
 })
 
-test('#transitionTo throws a useful error when called with an abstract route', () => {
+test('#transitionTo throws an useful error when called with an abstract route', () => {
   router.map((route) => {
     route('foo', {abstract: true})
   }).listen()
-  try {
+
+  assert.exception(function () {
     router.transitionTo('foo')
-  } catch (err) {
-    assert.equals(err.message, 'No route is named foo')
-  }
+  }, {message: 'No route is named foo'})
 })
 
 test('#transitionTo called on an abstract route with a child index route should activate the index route', async () => {


### PR DESCRIPTION
Fixes #160 and #151 

This change will forward transitions for abstract routes to its index route (path === '') if any

It's the same behavior as used by Ember. From its docs:
"If the user navigates to /posts, the current route will be posts.index, and the posts/index template will be rendered into the {{outlet}} in the posts template."

Here's a fiddle showing the behavior (trasitioning to 'groups' activates 'groups.index')
http://jsfiddle.net/qeVGG/14/


